### PR TITLE
trying to fix test

### DIFF
--- a/t/library.t
+++ b/t/library.t
@@ -3,7 +3,7 @@ use Test::More;
 use Mojo::Pg;
 use Test::Mojo;
 
-my $t = Test::Mojo->new('lite_app');
+my $t = Test::Mojo->new;
 
 $t->post_ok('/', json => {RFID => '12.34.56.78'})
   ->status_is(200);


### PR DESCRIPTION
creates this error:
t/library.t .. Mojo::Reactor::EV: I/O watcher failed: Can't call method "build_tx" on an undefined value at /usr/local/share/perl/5.24.1/Mojo/Server.pm line 23.
# Premature connection close

not ok 1 - POST /
not ok 2 - 200 OK
1..2

#   Failed test 'POST /'
#   at t/library.t line 8.

#   Failed test '200 OK'
#   at t/library.t line 8.
#          got: undef
#     expected: '200'
# Looks like you failed 2 tests of 2.
Dubious, test returned 2 (wstat 512, 0x200)
Failed 2/2 subtests 

Test Summary Report
-------------------
t/library.t (Wstat: 512 Tests: 2 Failed: 2)
  Failed tests:  1-2
  Non-zero exit status: 2
Files=1, Tests=2, 15 wallclock secs ( 0.02 usr  0.00 sys +  0.17 cusr  0.00 csys =  0.19 CPU)
Result: FAIL